### PR TITLE
HFP-4332 Fix as subcontent

### DIFF
--- a/src/entries/app.js
+++ b/src/entries/app.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Editor from '../scripts/editor';
-import { isBranching } from '../scripts/helpers/Library';
+import { findEditorForm, isBranching } from '../scripts/helpers/Library';
 import {t} from "../scripts/helpers/translate";
 
 /*global H5PEditor*/
@@ -106,7 +106,7 @@ H5PEditor.widgets.branchingScenario = H5PEditor.BranchingScenario = (function ()
           disableExtraTitleField: false
         };
       }
-      
+
       // For all other libraries, use the function from core
       return getLibraryMetadataSettings(library);
     };
@@ -393,6 +393,7 @@ H5PEditor.widgets.branchingScenario = H5PEditor.BranchingScenario = (function ()
     this.editor = ReactDOM.render(
       (<Editor
         parent={ this.parent }
+        form={ findEditorForm(this) }
         content={ this.content }
         getNewContent={ this.getNewContent.bind(this) }
         libraries={ this.libraries }

--- a/src/entries/app.js
+++ b/src/entries/app.js
@@ -325,6 +325,14 @@ H5PEditor.widgets.branchingScenario = H5PEditor.BranchingScenario = (function ()
     // Use full width
     document.documentElement.style.maxWidth = document.body.style.maxWidth = 'none';
 
+    /*
+     * Extra container to prevent React from failing when Branching Scenario instance is
+     * pasted over existing instance, because H5P core removes React content without React.
+     */
+    const container = document.createElement('div');
+    container.classList.add('h5p-branching-scenario-container');
+    $wrapper.get(0).appendChild(container);
+
     /**
      * Runs after semi-fullscreen has been entered.
      *
@@ -400,7 +408,7 @@ H5PEditor.widgets.branchingScenario = H5PEditor.BranchingScenario = (function ()
         onContentChanged={ this.handleContentChanged.bind(this) }
         onToggleFullscreen={ toggleSemiFullscreen }
         main={ this }
-      />), $wrapper.get(0)
+      />), container
     );
   };
 

--- a/src/scripts/components/Tab.scss
+++ b/src/scripts/components/Tab.scss
@@ -1,6 +1,6 @@
 @import '../../styles/main.scss';
 
-.h5p-branchingscenario-editor .h5peditor-form {
+.h5p-branchingscenario-editor .bswrapper {
   .tab-panel {
   	display: none;
     overflow: hidden;

--- a/src/scripts/components/TabViewTranslations.js
+++ b/src/scripts/components/TabViewTranslations.js
@@ -11,9 +11,9 @@ export default class TabViewTranslations extends React.Component {
 
   componentDidMount() {
     // Remove header, should not be included in custom editor
-    this.props.parent.$common.find('p.desc').remove();
+    this.props.form.$common.find('p.desc').remove();
 
-    H5PEditor.setCommonFieldsWrapper(this.props.parent, this.commonFields.current);
+    H5PEditor.setCommonFieldsWrapper(this.props.form, this.commonFields.current);
   }
 
   render() {

--- a/src/scripts/editor.js
+++ b/src/scripts/editor.js
@@ -59,7 +59,7 @@ export default class Editor extends React.Component {
     window.H5PEditor.LibraryListCache.getLibraries(this.props.libraries, this.handleLibrariesFetched);
 
     // Add title field
-    const titleField = this.props.main.parent.metadataForm.getExtraTitleField();
+    const titleField = this.props.form.metadataForm.getExtraTitleField();
     titleField.$item.find('input')[0].placeholder = t('enterTitleHere');
     titleField.$item.prependTo(this.topbar);
 
@@ -557,7 +557,7 @@ export default class Editor extends React.Component {
           </Tab>
           <Tab title={t('translations')} className="bs-editor-translations-tab">
             <TabViewTranslations
-              parent={this.props.parent}
+              form={this.props.form}
             />
           </Tab>
           <Tab title={t('getHelp')} className="bs-editor-tutorial-tab">
@@ -567,7 +567,7 @@ export default class Editor extends React.Component {
           </Tab>
           <Tab title={t('metadata')} className="bs-editor-metadata-tab">
             <TabViewMetadata
-              metadataForm={this.props.main.parent.metadataForm}
+              metadataForm={this.props.form.metadataForm}
             />
           </Tab>
         </Tabs>
@@ -575,7 +575,7 @@ export default class Editor extends React.Component {
           this.state.isShowingPreview &&
           <Preview
             tour={this.state.tour}
-            params={this.props.parent.params}
+            params={this.props.form.params}
             hasLoadedLibraries={this.state.hasLoadedLibraries}
             previewId={this.state.previewId}
             goToEditor={() => this.togglePreview()}

--- a/src/scripts/helpers/Library.js
+++ b/src/scripts/helpers/Library.js
@@ -111,11 +111,31 @@ const getBranchingChildren = (content) => {
   return children;
 };
 
+/**
+ * Find editor form for given semantics field instance.
+ * @param {object} semanticsFieldInstance Semantics field instance to get form for.
+ * @returns {H5PEditor.Form|boolean} Form if found, else false.
+ */
+const findEditorForm = (semanticsFieldInstance) => {
+  let current = semanticsFieldInstance;
+
+  while (current && typeof current === 'object') {
+    if (current instanceof H5PEditor.Form) {
+      return current;
+    }
+
+    current = current.parent;
+  }
+
+  return false;
+}
+
 export {
   isBranching,
   getAlternativeName,
   getMachineName,
   hasNextContent,
   find,
-  getBranchingChildren
+  getBranchingChildren,
+  findEditorForm
 };


### PR DESCRIPTION
When merged in, will fix issues that prevent using the Branching Scenario Editor as subcontent.

Current issues as subcontent:
- Editor assumes that the H5PEditor.Form is its direct parent.
- When pasting Branching Scenario content over Branching Scenario content, React fails because H5P core removes React content without React.
- Editor assumes fixed position of .h5peditor-form in DOM.